### PR TITLE
Implementation of UTAG setpoint associated with EVR events

### DIFF
--- a/evrApp/Db/evrevent.db
+++ b/evrApp/Db/evrevent.db
@@ -26,3 +26,17 @@ record(calc, "$(EN)Cnt-I") {
   field(INPA, "$(EN)Cnt-I NPP")
   field(TSEL, "$(EN)-SP.TIME")
 }
+
+
+# Mapping between hardware event code and a software database event
+#
+# Macros:
+#  EN = record name prefix
+#  OBJ = EVR devObj name
+#  CODE = Event code (hardware)
+record(int64out, "$(EN)-UTag-SP") {
+  field(DTYP, "UTAG Source")
+  field(OUT , "@OBJ=$(OBJ),Code=$(CODE)")
+  field(VAL , "0")
+  info(autosaveFields_pass0, "OUT VAL")
+}

--- a/evrApp/src/Makefile
+++ b/evrApp/src/Makefile
@@ -26,6 +26,8 @@ evr_SRCS += evrGTIF.cpp
 
 evr_SRCS += devEvrStringIO.cpp
 
+evr_SRCS += devEvrUtag.cpp
+
 evr_SRCS += devEvrEvent.cpp
 evr_SRCS += devEvrMapping.cpp
 

--- a/evrApp/src/devEvrEvent.cpp
+++ b/evrApp/src/devEvrEvent.cpp
@@ -153,7 +153,13 @@ try {
         post_event(prec->val);
 
     if(prec->tse==epicsTimeEventDeviceTime){
-        p->evr->getTimeStamp(&prec->time,p->event);
+        epicsTimeStampUTag ts;
+        p->evr->getTimeStamp(&ts, p->event);
+        prec->time.secPastEpoch = ts.secPastEpoch;
+        prec->time.nsec = ts.nsec;
+#ifdef DBR_UTAG
+        prec->utag = static_cast<epicsUInt64>(ts.utag);
+#endif
     }
 
     return 0;
@@ -197,9 +203,14 @@ try {
 #endif
 
     if(prec->tse==epicsTimeEventDeviceTime){
-        p->evr->getTimeStamp(&prec->time,p->event);
+        epicsTimeStampUTag ts;
+        p->evr->getTimeStamp(&ts, p->event);
+        prec->time.secPastEpoch = ts.secPastEpoch;
+        prec->time.nsec = ts.nsec;
+#ifdef DBR_UTAG
+        prec->utag = static_cast<epicsUInt64>(ts.utag);
+#endif
     }
-
     return 0;
 } catch(std::runtime_error& e) {
     recGblRecordError(S_dev_noDevice, (void*)prec, e.what());
@@ -217,7 +228,13 @@ static long process_event(eventRecord *prec)
     long ret=0;
 try {
     if(prec->tse==epicsTimeEventDeviceTime){
-        p->evr->getTimeStamp(&prec->time,p->event);
+        epicsTimeStampUTag ts;
+        p->evr->getTimeStamp(&ts, p->event);
+        prec->time.secPastEpoch = ts.secPastEpoch;
+        prec->time.nsec = ts.nsec;
+#ifdef DBR_UTAG
+        prec->utag = static_cast<epicsUInt64>(ts.utag);
+#endif
     }
 
     return 0;

--- a/evrApp/src/devEvrUtag.cpp
+++ b/evrApp/src/devEvrUtag.cpp
@@ -1,0 +1,149 @@
+/*************************************************************************\
+* Copyright (c) 2010 Brookhaven Science Associates, as Operator of
+*     Brookhaven National Laboratory.
+* Copyright (c) 2015 Paul Scherrer Institute (PSI), Villigen, Switzerland
+* Copyright (c) 2023 European Spallation Source ERIC (ESS), Lund, Sweden
+* mrfioc2 is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+/*
+ * Author: Joao Paulo Martins <joaopaulosm@gmail.com>
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <epicsExport.h>
+#include <dbAccess.h>
+#include <devSup.h>
+#include <recGbl.h>
+#include <devLib.h> // For S_dev_*
+#include <alarm.h>
+#include <errlog.h>
+
+#include <int64outRecord.h>
+#include <epicsVersion.h>
+
+#include "devObj.h"
+#include "evr/evr.h"
+
+#include "linkoptions.h"
+
+#include <stdexcept>
+#include <string>
+
+struct priv {
+    EVR* evr;
+    char obj[30];
+    int event;
+    epicsUTag utag;
+};
+
+static const
+linkOptionDef utagdef[] =
+{
+    linkString  (priv, obj , "OBJ"  , 1, 0),
+    linkInt32   (priv, event, "Code", 1, 0),
+    linkOptionEnd
+};
+
+static
+long add_record(struct dbCommon *prec, struct link* link)
+{
+    long ret=0;
+try {
+    assert(link->type==INST_IO);
+
+    mrf::auto_ptr<priv> p(new priv);
+    p->utag=0;
+    p->event=0;
+
+    if (linkOptionsStore(utagdef, p.get(), link->value.instio.string, 0))
+        throw std::runtime_error("Couldn't parse link string");
+
+    mrf::Object *O=mrf::Object::getObject(p->obj);
+    if(!O) {
+        errlogPrintf("%s: failed to find object '%s'\n", prec->name, p->obj);
+        return S_db_errArg;
+    }
+    p->evr=dynamic_cast<EVR*>(O);
+    if(!p->evr)
+        throw std::runtime_error("Failed to lookup device");
+
+    prec->dpvt=(void*)p.release();
+
+    return 0;
+} catch(std::runtime_error& e) {
+    recGblRecordError(S_dev_noDevice, (void*)prec, e.what());
+    ret=S_dev_noDevice;
+} catch(std::exception& e) {
+    recGblRecordError(S_db_noMemory, (void*)prec, e.what());
+    ret=S_db_noMemory;
+}
+    return ret;
+}
+
+static
+long del_record(struct dbCommon *prec)
+{
+    priv *p=static_cast<priv*>(prec->dpvt);
+    long ret=0;
+    if (!p) return 0;
+try {
+
+    prec->dpvt=0;
+
+} catch(std::runtime_error& e) {
+    recGblRecordError(S_dev_noDevice, (void*)prec, e.what());
+    ret=S_dev_noDevice;
+} catch(std::exception& e) {
+    recGblRecordError(S_db_noMemory, (void*)prec, e.what());
+    ret=S_db_noMemory;
+}
+    return ret;
+}
+
+static long process_int64out(int64outRecord *prec)
+{
+    priv *p=static_cast<priv*>(prec->dpvt);
+    long ret=0;
+try {
+
+    // Inject the value as the UTAG reference
+    p->utag = static_cast<epicsUTag>(prec->val);
+    p->evr->eventUtagSet(p->event, p->utag);
+#ifdef DBR_UTAG
+    prec->utag = static_cast<epicsUInt64>(p->utag);
+#endif
+
+    return 0;
+} catch(std::runtime_error& e) {
+    recGblRecordError(S_dev_noDevice, (void*)prec, e.what());
+    ret=S_dev_noDevice;
+} catch(std::exception& e) {
+    recGblRecordError(S_db_noMemory, (void*)prec, e.what());
+    ret=S_db_noMemory;
+}
+    return ret;
+}
+
+
+static
+long add_int64out(struct dbCommon *precord)
+{
+    return add_record(precord, &((struct int64outRecord*)precord)->out);
+}
+
+dsxt dxtINT64UTAGEVR={add_int64out,del_record};
+static common_dset devINT64UTAGEVR = {
+  6, NULL,
+  dset_cast(&init_dset<&dxtINT64UTAGEVR>),
+  (DEVSUPFUN) init_record_empty,
+  (DEVSUPFUN) NULL,
+  dset_cast(&process_int64out),
+  NULL };
+
+extern "C" {
+
+epicsExportAddress(dset,devINT64UTAGEVR);
+
+}

--- a/evrApp/src/evr/evr.h
+++ b/evrApp/src/evr/evr.h
@@ -34,6 +34,16 @@ enum TSSource {
   TSSourceDBus4=2
 };
 
+#ifndef DBR_UTAG
+  typedef epicsUInt32     epicsUTag;
+#endif
+
+struct epicsTimeStampUTag {
+    epicsUInt32    secPastEpoch;   /**< \brief seconds since 0000 Jan 1, 1990 */
+    epicsUInt32    nsec;           /**< \brief nanoseconds within second */
+    epicsUTag      utag;           /**< \brief user defined tag */
+};
+
 /**@brief Base interface for EVRs.
  *
  * This is the interface which the generic EVR device support
@@ -147,6 +157,7 @@ public:
    *@return false When ts could not be updated
    */
   virtual bool getTimeStamp(epicsTimeStamp *ts,epicsUInt32 event)=0;
+  virtual bool getTimeStamp(epicsTimeStampUTag *ts,epicsUInt32 event) {return 0;};
 
   /** Returns the current value of the Timestamp Event Counter
    *@param tks Pointer to be filled with the counter value
@@ -189,6 +200,15 @@ public:
   /*@{*/
   void setSourceTSraw(epicsUInt32 r){setSourceTS((TSSource)r);};
   epicsUInt32 SourceTSraw() const{return (TSSource)SourceTS();};
+  /*@}*/
+
+  /**\defgroup utagman UTAG Management
+   *
+   * Get/Set UTAG value for specific event
+   */
+  /*@{*/
+  virtual epicsUTag eventUtag(const epicsUInt32 event) const {return 0;};
+  virtual void eventUtagSet(const epicsUInt32 event, epicsUTag tag) {};
   /*@}*/
 
 private:

--- a/evrApp/src/evrSupport.dbd
+++ b/evrApp/src/evrSupport.dbd
@@ -45,3 +45,6 @@ registrar(EVRTime_Registrar)
 registrar(ntpShmRegister)
 driver(ntpShared)
 variable(mrmGTIFEnable, int)
+
+# '@C=..., Code=hweventnum'
+device(int64out,    INST_IO, devINT64UTAGEVR, "UTAG Source")

--- a/evrMrmApp/src/drvem.h
+++ b/evrMrmApp/src/drvem.h
@@ -72,8 +72,12 @@ struct eventCode {
     size_t waitingfor;
     bool again;
 
+    // UTAG associated to event
+    epicsUTag utag;
+
     eventCode():owner(0), interested(0), last_sec(0)
-            ,last_evt(0), waitingfor(0), again(false)
+            ,last_evt(0), waitingfor(0), again(false),
+            utag(0)
     {
         scanIoInit(&occured);
         // done_cb - initialized in EVRMRM::EVRMRM()
@@ -174,12 +178,14 @@ public:
     virtual IOSCANPVT TimeStampValidEvent() const OVERRIDE FINAL {return timestampValidChange;}
 
     virtual bool getTimeStamp(epicsTimeStamp *ts,epicsUInt32 event) OVERRIDE FINAL;
+    virtual bool getTimeStamp(epicsTimeStampUTag *ts,epicsUInt32 event) OVERRIDE FINAL;
     virtual bool getTicks(epicsUInt32 *tks) OVERRIDE FINAL;
     virtual IOSCANPVT eventOccurred(epicsUInt32 event) const OVERRIDE FINAL;
     virtual void eventNotifyAdd(epicsUInt32, eventCallback, void*) OVERRIDE FINAL;
     virtual void eventNotifyDel(epicsUInt32, eventCallback, void*) OVERRIDE FINAL;
 
-    bool convertTS(epicsTimeStamp* ts);
+    template<typename TimeStampT>
+    bool convertTS(TimeStampT* ts);
 
     virtual epicsUInt16 dbus() const OVERRIDE FINAL;
 
@@ -192,6 +198,9 @@ public:
     {SCOPED_LOCK(evrLock);return count_FIFO_sw_overrate;}
     virtual epicsUInt32 FIFOEvtCount() const OVERRIDE FINAL {return count_fifo_events;}
     virtual epicsUInt32 FIFOLoopCount() const OVERRIDE FINAL {return count_fifo_loops;}
+
+    virtual epicsUTag eventUtag(const epicsUInt32 event) const OVERRIDE FINAL;
+    virtual void eventUtagSet(const epicsUInt32 event, epicsUTag tag) OVERRIDE FINAL;
 
     void enableIRQ(void);
 


### PR DESCRIPTION
This contribution is a candidate for `UTAG` manipulation inside mrfioc2. The main idea is that every EVR event (0-255) has a 64 bits* number (tag) associated to it. This tag value will be copied to the `UTAG` field of the event counter record, together with the precise timestamp of the event arrival in the EVR. Newer versions of EPICS Base will copy `UTAG` to other records via the `TSEL` mechanism, reinforcing the role of the Event Counter record as not only the source of timestamp but also the source of the `UTAG`.
 
\* If 64 bits is not supported, the value will be 32 bits.

Commit history (squashed into a single commit):

* First implementation, simple set/get UTAG

* Remove I/O Intr link that is not needed

* Adding UTAG for each event

* Add new getTimeStampUTag method to avoid mutex being locked twice in a row

* Minor adjust in UTAG setpoint record name

* Fix typo on nanosseconds assignment; convertTS is now template

* Overload getTimeStamp; Use define guards to compile for older versions; Clean-up comments and defines

* Additional comments and clean-up